### PR TITLE
Add token-based security layer

### DIFF
--- a/marathon-app/src/main/java/com/rzerosystems/marathonapp/security/SecurityConfig.java
+++ b/marathon-app/src/main/java/com/rzerosystems/marathonapp/security/SecurityConfig.java
@@ -1,0 +1,30 @@
+package com.rzerosystems.marathonapp.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+/**
+ * Configures Spring Security to use token based authentication.
+ */
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final TokenAuthenticationFilter tokenAuthenticationFilter;
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+            .csrf().disable()
+            .authorizeRequests()
+                .antMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                .anyRequest().authenticated()
+            .and()
+            .addFilterBefore(tokenAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+}

--- a/marathon-app/src/main/java/com/rzerosystems/marathonapp/security/TokenAuthenticationFilter.java
+++ b/marathon-app/src/main/java/com/rzerosystems/marathonapp/security/TokenAuthenticationFilter.java
@@ -1,0 +1,41 @@
+package com.rzerosystems.marathonapp.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Simple filter that checks for a bearer token in the Authorization header.
+ */
+@Component
+public class TokenAuthenticationFilter extends OncePerRequestFilter {
+
+    @Value("${security.auth.token:}")
+    private String apiToken;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String header = request.getHeader("Authorization");
+        if (header != null && header.startsWith("Bearer ") && !apiToken.isBlank()) {
+            String token = header.substring(7);
+            if (apiToken.equals(token)) {
+                var auth = new UsernamePasswordAuthenticationToken(
+                        "token-user", null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/marathon-app/src/main/java/com/rzerosystems/marathonapp/security/WebOAuth2Config.java
+++ b/marathon-app/src/main/java/com/rzerosystems/marathonapp/security/WebOAuth2Config.java
@@ -35,7 +35,7 @@ import java.util.ArrayList;
 //@Order(1000)
 public class WebOAuth2Config extends WebSecurityConfigurerAdapter {
 
-  static final String GOOGLE_LOGIN_URL = "/login/google";
+  static final String KEYCLOAK_LOGIN_URL = "/login/keycloak";
   static final String GITHUB_LOGIN_URL = "/login/github";
 
   private final WebOAuth2ConfigHelper webOAuth2ConfigHelper;
@@ -70,15 +70,15 @@ public class WebOAuth2Config extends WebSecurityConfigurerAdapter {
   private Filter ssoFilter() {
     var compositeFilter = new CompositeFilter();
     var filters = new ArrayList<Filter>();
-    filters.add(googleOAuth2AuthProcessingFilter());
+    filters.add(keycloakOAuth2AuthProcessingFilter());
     filters.add(githubOAuth2AuthProcessingFilter());
     compositeFilter.setFilters(filters);
     return compositeFilter;
   }
 
-  private Filter googleOAuth2AuthProcessingFilter() {
+  private Filter keycloakOAuth2AuthProcessingFilter() {
     var webOAuth2AuthProcessingFilter =
-        new WebOAuth2AuthProcessingFilter(GOOGLE_LOGIN_URL, googleClientResource());
+        new WebOAuth2AuthProcessingFilter(KEYCLOAK_LOGIN_URL, keycloakClientResource());
     webOAuth2AuthProcessingFilter.init();
     return webOAuth2AuthProcessingFilter;
   }
@@ -91,8 +91,8 @@ public class WebOAuth2Config extends WebSecurityConfigurerAdapter {
   }
 
   @Bean
-  @ConfigurationProperties("google")
-  ClientResources googleClientResource() {
+  @ConfigurationProperties("keycloak")
+  ClientResources keycloakClientResource() {
     return new ClientResources();
   }
 

--- a/marathon-app/src/main/resources/application.properties
+++ b/marathon-app/src/main/resources/application.properties
@@ -8,7 +8,8 @@ api.result.url=https://global-marathon-api.herokuapp.com/v1/results
 api.key.url=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySUQiOiJiMTAwODMxZC00NjgzLTQ0NWUtYjZiZC0wMmMzY2ZhMTZmZGEifQ.-UU5qRh1uDuKo7sFEtGYxplUO57BhRey5e0eA722xOM
 
 
-google.client.client-id=[google-client-id]
-google.client.client-secret=[google-client-secret]
+keycloak.client.client-id=[keycloak-client-id]
+keycloak.client.client-secret=[keycloak-client-secret]
 github.client.client-id=[github-client-id]
-github.client.client-secret=[google-client-secret]
+github.client.client-secret=[github-client-secret]
+security.auth.token=secret-token


### PR DESCRIPTION
## Summary
- add Spring Security config enforcing bearer token authentication
- implement filter to process Authorization header tokens
- expose configurable token property
- replace Google OAuth2 client with Keycloak provider configuration

## Testing
- `./mvnw -q test` *(fails: java.net.SocketException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a25d8ac3d08330bc1aab33af3fc4d9